### PR TITLE
Add JSON export and web UI for character stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # chinese2
 The repository for testing Codex on my Chinese project
+
+## Character statistics front-end
+
+Run the analyzer with the `--json` option to produce `stats.json` which is
+consumed by the web UI:
+
+```bash
+python analyze_characters.py --json stats.json
+```
+
+Then open `index.html` in a browser. The page will display the total and unique
+character counts as well as a table listing every character with its count and
+frequency.

--- a/analyze_characters.py
+++ b/analyze_characters.py
@@ -1,6 +1,7 @@
 import glob
 from collections import Counter
 import argparse
+import json
 
 
 def analyze_stories(pattern: str) -> tuple[int, list[tuple[str, int]]]:
@@ -27,16 +28,35 @@ def print_stats(total: int, sorted_counts: list[tuple[str, int]], top: int) -> N
         print(f"{ch:^10} {count:>10} {freq:>9.2f}%")
 
 
+def write_json(total: int, sorted_counts: list[tuple[str, int]], path: str) -> None:
+    data = {
+        "total": total,
+        "stats": [
+            {
+                "character": ch,
+                "count": count,
+                "frequency": count / total * 100,
+            }
+            for ch, count in sorted_counts
+        ],
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Analyze story character frequencies")
     parser.add_argument('-p', '--pattern', default='story*.txt',
                         help='Glob pattern for story files')
     parser.add_argument('-t', '--top', type=int, default=10,
                         help='Number of top characters to display')
+    parser.add_argument('-j', '--json', help='Write full statistics to JSON file')
     args = parser.parse_args()
 
     total, counts = analyze_stories(args.pattern)
     print_stats(total, counts, args.top)
+    if args.json:
+        write_json(total, counts, args.json)
 
 
 if __name__ == '__main__':

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Character Statistics</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Character Statistics</h1>
+        <p>Total characters: <span id="total">0</span></p>
+        <p>Unique characters: <span id="unique">0</span></p>
+        <table id="stats">
+            <thead>
+                <tr><th>Character</th><th>Count</th><th>Frequency</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,16 @@
+fetch('stats.json')
+  .then(r => r.json())
+  .then(data => {
+    document.getElementById('total').textContent = data.total;
+    document.getElementById('unique').textContent = data.stats.length;
+    const tbody = document.querySelector('#stats tbody');
+    data.stats.forEach(item => {
+      const tr = document.createElement('tr');
+      const freq = item.frequency.toFixed(2) + '%';
+      tr.innerHTML = `<td>${item.character}</td><td>${item.count}</td><td>${freq}</td>`;
+      tbody.appendChild(tr);
+    });
+  })
+  .catch(err => {
+    console.error('Failed to load stats:', err);
+  });

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f8f9fa;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+h1 {
+    text-align: center;
+}
+
+#stats {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+#stats th, #stats td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #ddd;
+    text-align: center;
+}
+
+#stats th {
+    background: #007bff;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- extend `analyze_characters.py` with JSON export capability
- document how to generate `stats.json` and view the statistics
- add basic HTML/CSS/JS front-end to display character counts and frequencies

## Testing
- `python analyze_characters.py --json stats.json | head`

------
https://chatgpt.com/codex/tasks/task_e_684017881bc0832ab4c3dcc6f48a4b6d