### PR TITLE
Add static HTML generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ python analyze_characters.py --json stats.json
 Then open `index.html` in a browser. The page will display the total and unique
 character counts as well as a table listing every character with its count and
 frequency.
+
+## Generating a static page with Python
+
+If you prefer a single self-contained HTML file you can run
+`generate_page.py`. It analyzes all `story*.txt` files and writes `stats.html`
+with the statistics embedded directly in the page:
+
+```bash
+python generate_page.py
+```
+
+Open `stats.html` in a browser after running the command.

--- a/generate_page.py
+++ b/generate_page.py
@@ -1,0 +1,97 @@
+"""Generate a static HTML page with character statistics."""
+
+from analyze_characters import analyze_stories
+
+STYLE = """
+body {
+    font-family: Arial, sans-serif;
+    background: #f8f9fa;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+h1 {
+    text-align: center;
+}
+
+#stats {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+#stats th, #stats td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #ddd;
+    text-align: center;
+}
+
+#stats th {
+    background: #007bff;
+    color: #fff;
+}
+"""
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <title>Character Statistics</title>
+    <style>{style}</style>
+</head>
+<body>
+    <div class=\"container\">
+        <h1>Character Statistics</h1>
+        <p>Total characters: {total}</p>
+        <p>Unique characters: {unique}</p>
+        <table id=\"stats\">
+            <thead>
+                <tr><th>Character</th><th>Count</th><th>Frequency</th></tr>
+            </thead>
+            <tbody>
+                {rows}
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>
+"""
+
+
+def generate_html(total: int, counts: list[tuple[str, int]]) -> str:
+    """Return HTML for the given statistics."""
+    rows = []
+    for ch, count in counts:
+        freq = count / total * 100
+        rows.append(
+            f"<tr><td>{ch}</td><td>{count}</td><td>{freq:.2f}%</td></tr>"
+        )
+    return HTML_TEMPLATE.format(
+        style=STYLE,
+        total=total,
+        unique=len(counts),
+        rows="\n".join(rows),
+    )
+
+
+def main() -> None:
+    total, counts = analyze_stories("story*.txt")
+    html = generate_html(total, counts)
+    with open("stats.html", "w", encoding="utf-8") as f:
+        f.write(html)
+    print("Wrote stats.html")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_page.py` to build a self-contained statistics page
- document how to run the new generator

## Testing
- `python generate_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68401b7bca3c832a8a139ff7f48ae6a4