### PR TITLE
Add SQLite converter for vocabulary

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,0 +1,52 @@
+# Chinese Words SQLite Database
+
+This repository now includes a script to convert the Excel word list
+`bopomofo_translated.xlsx` into a structured SQLite database. The goal is to
+make it easy to query vocabulary data and track personal learning progress.
+
+## Schema
+
+The resulting database contains two tables:
+
+### `words`
+- `simplified` – the simplified Chinese form of the word
+- `frequency` – how often the word occurs in the source material
+- `pinyin` – standard pinyin pronunciation
+- `meaning` – English meaning or gloss
+- `bopomofo` – phonetic transcription in bopomofo
+
+All rows come directly from the Excel spreadsheet.
+
+### `user_words`
+- `simplified` – references a word in the `words` table (primary key)
+- `user_knows_word` – `0` or `1` indicating if the user claims to know the word
+- `known_probability` – floating value representing confidence (0–1 range)
+- `number_in_texts` – how many times the word appears in the reading texts
+
+Each word from the `words` table is automatically inserted into this table with
+default values so that learning progress can be tracked immediately.
+
+## Usage
+
+Run the converter with Python (requires `pandas` and `sqlite3` which ships with
+Python):
+
+```bash
+python import_words.py
+```
+
+By default it reads `bopomofo_translated.xlsx` and writes
+`chinese_words.db`. You can supply custom paths:
+
+```bash
+python import_words.py path/to/file.xlsx --db my.db
+```
+
+## Possible Extensions
+
+- Add extra columns to `user_words` such as the date a word was first seen or
+  last reviewed.
+- Store multiple users' progress by introducing a separate `users` table and
+  referencing it from `user_words` with a `user_id` column.
+- Include links to example sentences or audio pronunciations in the `words`
+  table for richer study material.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ python generate_page.py
 ```
 
 Open `stats.html` in a browser after running the command.
+
+## Vocabulary database
+
+`import_words.py` converts the Excel word list into an SQLite database. Run it
+with Python (requires `pandas`):
+
+```bash
+python import_words.py
+```
+
+This creates `chinese_words.db` containing two tables: `words` with the
+vocabulary data and `user_words` for tracking individual progress. See
+`DATABASE.md` for a complete description of the schema.

--- a/import_words.py
+++ b/import_words.py
@@ -1,0 +1,70 @@
+"""Create an SQLite database from the bopomofo Excel data."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+
+
+DEFAULT_DB_PATH = "chinese_words.db"
+
+
+def import_excel(excel_path: str, db_path: str = DEFAULT_DB_PATH) -> None:
+    """Read the Excel file and store its contents in an SQLite database.
+
+    Parameters
+    ----------
+    excel_path:
+        Path to ``bopomofo_translated.xlsx``.
+    db_path:
+        Location of the SQLite database to create or update.
+    """
+    df = pd.read_excel(excel_path)
+    with sqlite3.connect(db_path) as conn:
+        # main table with vocabulary
+        df.to_sql("words", conn, index=False, if_exists="replace")
+        # secondary table tracking a user's knowledge of each word
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_words (
+                simplified TEXT PRIMARY KEY,
+                user_knows_word INTEGER DEFAULT 0,
+                known_probability REAL DEFAULT 0.0,
+                number_in_texts INTEGER DEFAULT 0,
+                FOREIGN KEY(simplified) REFERENCES words(simplified)
+            )
+            """
+        )
+        # prepopulate user_words with the word list if not already present
+        existing = {
+            row[0]
+            for row in conn.execute(
+                "SELECT simplified FROM user_words"
+            )
+        }
+        to_insert = [(w,) for w in df["simplified"] if w not in existing]
+        if to_insert:
+            conn.executemany(
+                "INSERT INTO user_words(simplified) VALUES (?)", to_insert
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import words into an SQLite database")
+    parser.add_argument(
+        "excel", nargs="?", default="bopomofo_translated.xlsx",
+        help="Path to the source Excel file"
+    )
+    parser.add_argument(
+        "--db", default=DEFAULT_DB_PATH, help="Output SQLite database path"
+    )
+    args = parser.parse_args()
+    import_excel(args.excel, args.db)
+    print(f"Database written to {args.db}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `import_words.py` to convert Excel word list to a sqlite database
- document database schema and usage in `DATABASE.md`
- mention new script in `README.md`

## Testing
- `python -m py_compile import_words.py`

------
https://chatgpt.com/codex/tasks/task_e_68402ca88b20832aadb309c549fa7621