### PR TITLE
Implement word selection server

### DIFF
--- a/FUNCTION_REFERENCE.md
+++ b/FUNCTION_REFERENCE.md
@@ -78,3 +78,16 @@ This document lists the public Python functions in this repository and briefly e
   Segments a story with `segment_text` and writes the tokens to a JSON
   file. The output is consumed by `text_selection.html` for marking
   known and unknown words.
+
+## server.py
+
+- `update_user_progress(known: list[str], unknown: list[str], db_path: str = "chinese_words.db") -> None`
+
+  Updates the `user_words` table based on the selected words. Encounter counts
+  are increased and `known_probability` is adjusted (+20% for known words,
+  halved for unknown words, always at least 1%).
+
+- `app`
+
+  Flask application serving the selection page and providing the
+  `/update_words` endpoint to receive the user's choices.

--- a/README.md
+++ b/README.md
@@ -27,4 +27,7 @@ Generate a list of tokens from one of the sample stories and open the demo page:
 python generate_tokens.py stories/story1.txt
 ```
 
-This writes `tokens.json` which is loaded by `text_selection.html`. Open the page in a browser to mark unknown words. Click words to highlight them and press **Show Results** to print the known and unknown lists.
+This writes `tokens.json` which is loaded by `text_selection.html`.
+Run `python server.py` and open `http://localhost:5000` to mark unknown
+words in the browser. Click words to highlight them and press
+**Show Results** to store the results in the database.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections import Counter
+import json
+import sqlite3
+from flask import Flask, jsonify, request, send_from_directory
+
+DB_PATH = "chinese_words.db"
+
+app = Flask(__name__, static_url_path="", static_folder=".")
+
+
+@app.route("/")
+def index():
+    return send_from_directory(".", "text_selection.html")
+
+
+@app.route("/tokens.json")
+def tokens():
+    return send_from_directory(".", "tokens.json")
+
+
+@app.route("/text_selection.js")
+def js_file():
+    return send_from_directory(".", "text_selection.js")
+
+
+@app.route("/update_words", methods=["POST"])
+def update_words():
+    data = request.get_json(force=True)
+    known = data.get("known", [])
+    unknown = data.get("unknown", [])
+    update_user_progress(known, unknown, DB_PATH)
+    return jsonify({"status": "ok"})
+
+
+def update_user_progress(known: list[str], unknown: list[str], db_path: str = DB_PATH) -> None:
+    counts = Counter(known + unknown)
+    known_set = set(known)
+    unknown_set = set(unknown)
+    with sqlite3.connect(db_path) as conn:
+        for word, count in counts.items():
+            row = conn.execute(
+                "SELECT user_knows_word, known_probability, number_in_texts FROM user_words WHERE simplified = ?",
+                (word,),
+            ).fetchone()
+            if row is None:
+                continue
+            user_knows, prob, num = row
+            num += count
+            if prob < 0.01:
+                prob = 0.01
+            if word in known_set:
+                user_knows = 1
+                prob *= 1.2
+            elif word in unknown_set:
+                user_knows = 0
+                prob *= 0.5
+            if prob < 0.01:
+                prob = 0.01
+            if prob > 1:
+                prob = 1
+            conn.execute(
+                "UPDATE user_words SET user_knows_word = ?, known_probability = ?, number_in_texts = ? WHERE simplified = ?",
+                (user_knows, prob, num, word),
+            )
+        conn.commit()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/text_selection.js
+++ b/text_selection.js
@@ -20,7 +20,7 @@ async function loadTokens() {
     });
 }
 
-function showResults() {
+async function showResults() {
     const words = Array.from(document.querySelectorAll('.word'));
     const known = [];
     const unknown = [];
@@ -33,7 +33,16 @@ function showResults() {
         }
     });
     const out = document.getElementById('output');
-    out.textContent = 'Known: ' + known.join(' ') + '\n\nUnknown: ' + unknown.join(' ');
+    out.textContent = 'Known: ' + known.join('') + '\n\nUnknown: ' + unknown.join('');
+    try {
+        await fetch('/update_words', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ known, unknown })
+        });
+    } catch (err) {
+        console.error('Failed to send results', err);
+    }
 }
 
 document.getElementById('show').addEventListener('click', showResults);


### PR DESCRIPTION
## Summary
- create a small Flask server for serving the demo and receiving word selections
- send selected words back to the server from the JS demo
- remove spaces from the result display
- update documentation and function reference

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68405df0f65c832aa0fe6f56234c5964