### PR TITLE
Improve demo layout and remove character spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,0 +1,55 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 600px;
+    margin: auto;
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+#text {
+    font-size: 1.2em;
+    line-height: 1.8;
+    margin-bottom: 1em;
+}
+
+.word {
+    cursor: pointer;
+    padding: 0;
+    user-select: none;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+.word:hover {
+    background-color: #eee;
+}
+.unknown {
+    background-color: #ffec99;
+}
+
+button {
+    padding: 6px 12px;
+    font-size: 1em;
+    border: none;
+    border-radius: 4px;
+    background-color: #007bff;
+    color: #fff;
+    cursor: pointer;
+}
+button:hover {
+    background-color: #0056b3;
+}
+
+pre {
+    background-color: #f0f0f0;
+    padding: 10px;
+    border-radius: 4px;
+    overflow-x: auto;
+}

--- a/text_selection.html
+++ b/text_selection.html
@@ -4,20 +4,6 @@
     <meta charset="UTF-8">
     <title>Word Selection</title>
     <link rel="stylesheet" href="style.css">
-    <style>
-    #text {
-        font-size: 1.2em;
-        line-height: 2;
-        margin-bottom: 1em;
-    }
-    .word {
-        cursor: pointer;
-        padding: 2px;
-    }
-    .unknown {
-        background-color: yellow;
-    }
-    </style>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- remove inline styles from text_selection.html
- add a new stylesheet with improved layout and no padding for words

## Testing
- `python -m py_compile search_words.py generate_tokens.py server.py import_words.py analyze_characters.py update_lesson_stats.py find_mismatched_words.py`
- `python generate_tokens.py stories/story1.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840604a2e90832a83c84b37e8c3a2d0