### PR TITLE
Add stats web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ This writes `tokens.json` which is loaded by `text_selection.html`.
 Run `python server.py` and open `http://localhost:5000` to mark unknown
 words in the browser. Click words to highlight them and press
 **Show Results** to store the results in the database.
+
+## Viewing learning statistics
+
+While the server is running, open `http://localhost:5000/stats` to see a table
+of all words that have been encountered. The page lists each word together with
+its current probability of being known and how many times it occurred in the
+texts.

--- a/server.py
+++ b/server.py
@@ -25,6 +25,30 @@ def js_file():
     return send_from_directory(".", "text_selection.js")
 
 
+@app.route("/stats")
+def stats_page():
+    return send_from_directory(".", "stats.html")
+
+
+@app.route("/stats.js")
+def stats_js():
+    return send_from_directory(".", "stats.js")
+
+
+@app.route("/stats_data")
+def stats_data():
+    with sqlite3.connect(DB_PATH) as conn:
+        rows = conn.execute(
+            "SELECT simplified, known_probability, number_in_texts "
+            "FROM user_words ORDER BY number_in_texts DESC, simplified LIMIT 100"
+        ).fetchall()
+    data = [
+        {"word": w, "probability": p, "interactions": n}
+        for w, p, n in rows
+    ]
+    return jsonify(data)
+
+
 @app.route("/update_words", methods=["POST"])
 def update_words():
     data = request.get_json(force=True)

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Word Statistics</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Word Statistics</h1>
+        <table id="stats">
+            <thead>
+                <tr><th>Word</th><th>Known Probability</th><th>Interactions</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="stats.js"></script>
+</body>
+</html>

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,15 @@
+async function loadStats() {
+    const res = await fetch('/stats_data');
+    const data = await res.json();
+    const tbody = document.querySelector('#stats tbody');
+    tbody.innerHTML = '';
+    data.forEach(entry => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${entry.word}</td>` +
+            `<td>${(entry.probability * 100).toFixed(1)}%</td>` +
+            `<td>${entry.interactions}</td>`;
+        tbody.append(tr);
+    });
+}
+
+loadStats();

--- a/style.css
+++ b/style.css
@@ -53,3 +53,19 @@ pre {
     border-radius: 4px;
     overflow-x: auto;
 }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1em;
+}
+
+th, td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
+}


### PR DESCRIPTION
## Summary
- add stats view on `/stats` with new Flask routes
- show top encountered words and probabilities
- style table in CSS
- document stats page in README

## Testing
- `python -m py_compile server.py`
- `python -m py_compile update_lesson_stats.py analyze_characters.py generate_tokens.py import_words.py search_words.py find_mismatched_words.py`
- *(fails: ModuleNotFoundError: No module named 'flask' when running server)*

------
https://chatgpt.com/codex/tasks/task_e_68406abf3ba0832ab38132542f4fbb1a