### PR TITLE
Move stats recalc button to top

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -8,13 +8,13 @@
 <body>
     <div class="container">
         <h1>Word Statistics</h1>
+        <button id="recalc">Recalculate based on the number of interactions</button>
         <table id="stats">
             <thead>
                 <tr><th>Word</th><th>Known Probability</th><th>Interactions</th></tr>
             </thead>
             <tbody></tbody>
         </table>
-        <button id="recalc">Recalculate based on the number of interactions</button>
     </div>
     <script src="stats.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- move Recalculate button above the statistics table so it's visible without scrolling

## Testing
- `npx eslint --version` *(fails: no npm project)*

------
https://chatgpt.com/codex/tasks/task_e_68407630686c832abac22a2b0ca10812