### PR TITLE
Implement logistic probability and unknown words panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,12 +6,30 @@ body {
 }
 
 .container {
-    max-width: 600px;
+    max-width: 900px;
     margin: auto;
     background-color: #ffffff;
     padding: 20px;
     border-radius: 8px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.layout {
+    display: flex;
+    gap: 20px;
+}
+
+#left {
+    flex: 1;
+}
+
+#right {
+    width: 250px;
+}
+
+#unknown-list {
+    list-style: none;
+    padding-left: 0;
 }
 
 #text {

--- a/text_selection.html
+++ b/text_selection.html
@@ -6,11 +6,17 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
-        <h1>Select Unknown Words</h1>
-        <div id="text"></div>
-        <button id="show">Show Results</button>
-        <pre id="output"></pre>
+    <div class="container layout">
+        <div id="left">
+            <h1>Select Unknown Words</h1>
+            <div id="text"></div>
+            <button id="show">Show Results</button>
+            <pre id="output"></pre>
+        </div>
+        <div id="right">
+            <h2>Words you probably don't know</h2>
+            <ul id="unknown-list"></ul>
+        </div>
     </div>
     <script src="text_selection.js"></script>
 </body>

--- a/text_selection.js
+++ b/text_selection.js
@@ -20,6 +20,18 @@ async function loadTokens() {
     });
 }
 
+async function loadUnknownWords() {
+    const res = await fetch('/unknown_words');
+    const words = await res.json();
+    const list = document.getElementById('unknown-list');
+    list.innerHTML = '';
+    words.forEach(w => {
+        const li = document.createElement('li');
+        li.textContent = w;
+        list.append(li);
+    });
+}
+
 async function showResults() {
     const words = Array.from(document.querySelectorAll('.word'));
     const known = [];
@@ -47,3 +59,4 @@ async function showResults() {
 
 document.getElementById('show').addEventListener('click', showResults);
 loadTokens();
+loadUnknownWords();


### PR DESCRIPTION
## Summary
- replace interaction linear formula with logistic curve and cap at 95%
- add `/unknown_words` endpoint
- show unknown words pane beside text selection UI
- style layout for new two-column page

## Testing
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_684077a810b4832a97d3e8848878b766