### PR TITLE
Add pinyin and translation to unknown word list

### DIFF
--- a/text_selection.html
+++ b/text_selection.html
@@ -15,7 +15,12 @@
         </div>
         <div id="right">
             <h2>Words you probably don't know</h2>
-            <ul id="unknown-list"></ul>
+            <table id="unknown-table">
+                <thead>
+                    <tr><th>Word</th><th>Pinyin</th><th>Meaning</th></tr>
+                </thead>
+                <tbody id="unknown-list"></tbody>
+            </table>
         </div>
     </div>
     <script src="text_selection.js"></script>

--- a/text_selection.js
+++ b/text_selection.js
@@ -26,9 +26,11 @@ async function loadUnknownWords() {
     const list = document.getElementById('unknown-list');
     list.innerHTML = '';
     words.forEach(w => {
-        const li = document.createElement('li');
-        li.textContent = w;
-        list.append(li);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${w.word}</td>` +
+            `<td>${w.pinyin}</td>` +
+            `<td>${w.meaning}</td>`;
+        list.append(tr);
     });
 }
 


### PR DESCRIPTION
## Summary
- show unknown words in a table with pinyin and first meaning
- modify JavaScript to insert new data structure
- expand server endpoint to supply pinyin and meaning

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407ae4e0f4832aae6168766cb8fb20