### PR TITLE
Add database viewer

### DIFF
--- a/database.html
+++ b/database.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Database Viewer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Database Contents</h1>
+        <div id="schema"></div>
+        <h2>Table Data</h2>
+        <table id="data-table">
+            <thead></thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="database.js"></script>
+</body>
+</html>

--- a/database.js
+++ b/database.js
@@ -1,0 +1,46 @@
+async function loadSchema() {
+    const res = await fetch('/db_schema');
+    const data = await res.json();
+    const container = document.getElementById('schema');
+    container.innerHTML = '';
+    Object.entries(data).forEach(([table, columns]) => {
+        const div = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.textContent = `Show ${table} data`;
+        btn.addEventListener('click', () => loadTable(table));
+        const fields = columns.map(c => `${c.name} (${c.type})`).join(', ');
+        div.innerHTML = `<h3>${table}</h3><p>${fields}</p>`;
+        div.append(btn);
+        container.append(div);
+    });
+}
+
+async function loadTable(name) {
+    const res = await fetch(`/table/${name}`);
+    const rows = await res.json();
+    const thead = document.querySelector('#data-table thead');
+    const tbody = document.querySelector('#data-table tbody');
+    thead.innerHTML = '';
+    tbody.innerHTML = '';
+    if (!rows.length) {
+        return;
+    }
+    const headerRow = document.createElement('tr');
+    Object.keys(rows[0]).forEach(col => {
+        const th = document.createElement('th');
+        th.textContent = col;
+        headerRow.append(th);
+    });
+    thead.append(headerRow);
+    rows.forEach(row => {
+        const tr = document.createElement('tr');
+        Object.values(row).forEach(val => {
+            const td = document.createElement('td');
+            td.textContent = val;
+            tr.append(td);
+        });
+        tbody.append(tr);
+    });
+}
+
+loadSchema();


### PR DESCRIPTION
## Summary
- add new `database.html` and `database.js` to inspect the database
- extend Flask server with API endpoints to serve schema and table data

## Testing
- `python -m py_compile server.py`
- *(fails: Flask not installed)* `python server.py`

------
https://chatgpt.com/codex/tasks/task_e_684156b0b5d0832aa3f368773444f387