### PR TITLE
Add tracking table for user interactions

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -6,7 +6,7 @@ make it easy to query vocabulary data and track personal learning progress.
 
 ## Schema
 
-The resulting database contains two tables:
+The resulting database contains three tables:
 
 ### `words`
 - `simplified` – the simplified Chinese form of the word
@@ -25,6 +25,16 @@ All rows come directly from the Excel spreadsheet.
 
 Each word from the `words` table is automatically inserted into this table with
 default values so that learning progress can be tracked immediately.
+
+### `word_interactions`
+- `id` – auto-incrementing unique row identifier
+- `simplified` – references a word in the `words` table
+- `interaction` – short string describing the type of interaction
+- `known` – `0` or `1` if the user indicated knowledge (may be `NULL`)
+- `timestamp` – Unix epoch time (seconds)
+
+Every encounter with a word is recorded in this table. It allows analysing the
+time between reviews and supports future interaction types beyond reading.
 
 ## Usage
 

--- a/FUNCTION_REFERENCE.md
+++ b/FUNCTION_REFERENCE.md
@@ -83,16 +83,21 @@ This document lists the public Python functions in this repository and briefly e
 
 - `update_user_progress(known: list[str], unknown: list[str], db_path: str = "chinese_words.db") -> None`
 
-  Updates the `user_words` table based on the selected words. Encounter counts
-  are increased but probabilities are not recomputed automatically. Instead
-  `known_probability` is set to `1.10` for words marked as known and `0.50` for
-  words marked as unknown. The `user_knows_word` column is updated accordingly.
+  Updates the `user_words` table and records every interaction in the
+  `word_interactions` table. Encounter counts are increased but probabilities
+  are not recomputed automatically. Instead `known_probability` is set to `1.10`
+  for words marked as known and `0.50` for words marked as unknown. The
+  `user_knows_word` column is updated accordingly.
 
 - `probability_from_interactions(count: int) -> float`
 
   Convert the number of times a word has been encountered into a probability of
   being known. One encounter yields 1% probability, 15 encounters about 50% and
   100 encounters about 95%.
+
+- `record_interaction(conn: sqlite3.Connection, word: str, interaction: str, known: int | None) -> None`
+
+  Inserts a single row into `word_interactions` with the current timestamp.
 
 - `app`
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ with Python (requires `pandas`):
 python import_words.py
 ```
 
-This creates `chinese_words.db` containing two tables: `words` with the
-vocabulary data and `user_words` for tracking individual progress. See
+This creates `chinese_words.db` containing three tables: `words` with the
+vocabulary data, `user_words` for tracking individual progress and
+`word_interactions` which logs every encounter with a word. See
 `DATABASE.md` for a complete description of the schema.
 
 ## Function Reference

--- a/import_words.py
+++ b/import_words.py
@@ -38,6 +38,19 @@ def import_excel(excel_path: str, db_path: str = DEFAULT_DB_PATH) -> None:
             )
             """
         )
+        # table recording every single interaction with a word
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS word_interactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                simplified TEXT NOT NULL,
+                interaction TEXT NOT NULL,
+                known INTEGER,
+                timestamp INTEGER NOT NULL,
+                FOREIGN KEY(simplified) REFERENCES words(simplified)
+            )
+            """
+        )
         # prepopulate user_words with the word list if not already present
         existing = {
             row[0]


### PR DESCRIPTION
## Summary
- create `word_interactions` table in `import_words.py`
- log interactions through new `record_interaction` helper
- update `update_user_progress` to store reading events
- document new table and functions

## Testing
- `python -m py_compile import_words.py server.py`
- `python import_words.py bopomofo_translated.xlsx --db test.db` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python - <<'EOF'
from server import update_user_progress
update_user_progress(['我','你'], ['他','我'])
EOF` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68415a35dcd0832abefd0f021ae8055b