### PR TITLE
Log word interactions and improve DB viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ python generate_tokens.py stories/story1.txt
 This writes `tokens.json` which is loaded by `text_selection.html`.
 Run `python server.py` and open `http://localhost:5000` to mark unknown
 words in the browser. Click words to highlight them and press
-**Show Results** to store the results in the database.
+**Show Results** to record your interaction with each word. The
+`user_words` table is no longer modified directly; instead every
+interaction is stored in `word_interactions` with a timestamp.
 
 ## Viewing learning statistics
 
@@ -40,3 +42,8 @@ of all words that have been encountered. The page lists each word together with
 its current probability of being known and how many times it occurred in the
 texts. A **Recalculate based on the number of interactions** button lets you
 recompute all probabilities from the stored interaction counts.
+
+## Inspecting the database
+
+While the server is running, open `http://localhost:5000/database` to see the
+structure of each table and browse their contents.

--- a/database.html
+++ b/database.html
@@ -8,6 +8,7 @@
 <body>
     <div class="container">
         <h1>Database Contents</h1>
+        <p>Select a table below to view its schema and data.</p>
         <div id="schema"></div>
         <h2>Table Data</h2>
         <table id="data-table">

--- a/database.js
+++ b/database.js
@@ -4,14 +4,30 @@ async function loadSchema() {
     const container = document.getElementById('schema');
     container.innerHTML = '';
     Object.entries(data).forEach(([table, columns]) => {
-        const div = document.createElement('div');
+        const section = document.createElement('section');
+        const heading = document.createElement('h3');
+        heading.textContent = table;
+        section.append(heading);
+
+        const colTable = document.createElement('table');
+        const thead = document.createElement('thead');
+        thead.innerHTML = '<tr><th>Column</th><th>Type</th></tr>';
+        const tbody = document.createElement('tbody');
+        columns.forEach(c => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${c.name}</td><td>${c.type}</td>`;
+            tbody.append(tr);
+        });
+        colTable.append(thead);
+        colTable.append(tbody);
+        section.append(colTable);
+
         const btn = document.createElement('button');
         btn.textContent = `Show ${table} data`;
         btn.addEventListener('click', () => loadTable(table));
-        const fields = columns.map(c => `${c.name} (${c.type})`).join(', ');
-        div.innerHTML = `<h3>${table}</h3><p>${fields}</p>`;
-        div.append(btn);
-        container.append(div);
+        section.append(btn);
+
+        container.append(section);
     });
 }
 


### PR DESCRIPTION
## Summary
- record reading interactions without updating `user_words`
- compute stats from the `word_interactions` table
- improve database viewer layout and instructions
- document new behaviour in README

## Testing
- `python -m py_compile server.py import_words.py update_lesson_stats.py analyze_characters.py search_words.py generate_tokens.py find_mismatched_words.py`
- `node -c database.js`

------
https://chatgpt.com/codex/tasks/task_e_68415c371814832abd7643c73e59a25b