### PR TITLE
Add lesson initialization helper

### DIFF
--- a/FUNCTION_REFERENCE.md
+++ b/FUNCTION_REFERENCE.md
@@ -105,3 +105,25 @@ This document lists the public Python functions in this repository and briefly e
   `/update_words` endpoint to receive the user's choices. It also exposes a
   `/recalculate` endpoint to recompute all probabilities from the stored
   interaction counts.
+
+## initial.py
+
+- `setup_database(excel_path: str = "bopomofo_translated.xlsx", db_path: str = "chinese_words.db") -> None`
+
+  Create the SQLite database from the Excel word list.
+
+- `count_lesson_words(lesson_dir: str = "lessons", db_path: str = "chinese_words.db") -> Counter`
+
+  Return a `Counter` with the number of times each word occurs across all lesson texts.
+
+- `update_lesson_statistics(db_path: str = "chinese_words.db", lesson_dir: str = "lessons") -> None`
+
+  Store the lesson word counts in the `user_words` table.
+
+- `upload_lesson_interactions(db_path: str = "chinese_words.db", lesson_dir: str = "lessons") -> None`
+
+  Record interactions for every word in the lesson texts as if the user had read them.
+
+- `main() -> None`
+
+  Execute the full initialisation workflow: create the database, populate statistics and log lesson interactions.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The repository for testing Codex on my Chinese project
 
 ## Vocabulary database
 
-`import_words.py` converts the Excel word list into an SQLite database. Run it
-with Python (requires `pandas`):
+`initial.py` sets up the SQLite database and preloads it with the lesson
+statistics. Run it with Python (requires `pandas`):
 
 ```bash
-python import_words.py
+python initial.py
 ```
 
 This creates `chinese_words.db` containing three tables: `words` with the

--- a/initial.py
+++ b/initial.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sqlite3
+import re
+from collections import Counter
+from pathlib import Path
+
+from import_words import import_excel
+from search_words import load_words, segment_text
+from server import update_user_progress
+
+DEFAULT_DB_PATH = "chinese_words.db"
+EXCEL_PATH = "bopomofo_translated.xlsx"
+LESSON_DIR = "lessons"
+
+
+def setup_database(excel_path: str = EXCEL_PATH, db_path: str = DEFAULT_DB_PATH) -> None:
+    """Create the SQLite database from the vocabulary spreadsheet."""
+    import_excel(excel_path, db_path)
+
+
+def count_lesson_words(
+    lesson_dir: str = LESSON_DIR, db_path: str = DEFAULT_DB_PATH
+) -> Counter[str]:
+    """Return word occurrence counts for all lesson texts."""
+    words = load_words(db_path)
+    chinese_re = re.compile(r"[\u4e00-\u9fff]+")
+    counter: Counter[str] = Counter()
+    for path in Path(lesson_dir).glob("Lesson*.txt"):
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        segments = segment_text(text, words)
+        for seg in segments:
+            if chinese_re.search(seg):
+                counter[seg] += 1
+    return counter
+
+
+def update_lesson_statistics(
+    db_path: str = DEFAULT_DB_PATH, lesson_dir: str = LESSON_DIR
+) -> None:
+    """Store lesson word counts in the ``user_words`` table."""
+    counts = count_lesson_words(lesson_dir, db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE user_words SET number_in_texts = 0")
+        for word, count in counts.items():
+            conn.execute(
+                "UPDATE user_words SET number_in_texts = ? WHERE simplified = ?",
+                (count, word),
+            )
+        conn.commit()
+
+
+def upload_lesson_interactions(
+    db_path: str = DEFAULT_DB_PATH, lesson_dir: str = LESSON_DIR
+) -> None:
+    """Record reading interactions for all words found in the lessons."""
+    words = load_words(db_path)
+    chinese_re = re.compile(r"[\u4e00-\u9fff]+")
+    known: list[str] = []
+    for path in Path(lesson_dir).glob("Lesson*.txt"):
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        segments = segment_text(text, words)
+        for seg in segments:
+            if chinese_re.search(seg):
+                known.append(seg)
+    update_user_progress(known, [], db_path)
+
+
+def main() -> None:
+    setup_database()
+    update_lesson_statistics()
+    upload_lesson_interactions()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `initial.py` for one-time setup tasks
- describe new initialisation workflow in `README.md`
- document new helper functions in `FUNCTION_REFERENCE.md`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684162027bf0832abcc3d9347e042024