### PR TITLE
Add flashcard interface

### DIFF
--- a/flashcard.html
+++ b/flashcard.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Flashcards</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container" id="card">
+        <h1 id="word"></h1>
+        <div id="pinyin"></div>
+        <div id="meaning" style="display:none;"></div>
+        <button id="reveal">Reveal Translation (Space)</button>
+        <div id="answer" style="display:none; margin-top:1em;">
+            <button id="know">I know this word (1)</button>
+            <button id="dontknow">I don't know this word (2)</button>
+        </div>
+    </div>
+    <script src="flashcard.js"></script>
+</body>
+</html>

--- a/flashcard.js
+++ b/flashcard.js
@@ -1,0 +1,60 @@
+let index = 0;
+let currentWord = null;
+
+async function loadWord() {
+    const res = await fetch(`/next_word?offset=${index}`);
+    const data = await res.json();
+    if (!data.word) {
+        document.getElementById('word').textContent = 'No more words';
+        document.getElementById('pinyin').textContent = '';
+        document.getElementById('meaning').textContent = '';
+        document.getElementById('reveal').style.display = 'none';
+        document.getElementById('answer').style.display = 'none';
+        return;
+    }
+    currentWord = data.word;
+    document.getElementById('word').textContent = data.word;
+    document.getElementById('pinyin').textContent = data.pinyin;
+    document.getElementById('meaning').textContent = data.meaning;
+    document.getElementById('meaning').style.display = 'none';
+    document.getElementById('answer').style.display = 'none';
+}
+
+function reveal() {
+    document.getElementById('meaning').style.display = 'block';
+    document.getElementById('answer').style.display = 'block';
+}
+
+async function record(known) {
+    if (!currentWord) return;
+    await fetch('/record_flashcard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ word: currentWord, known })
+    });
+    index++;
+    loadWord();
+}
+
+document.getElementById('reveal').addEventListener('click', reveal);
+document.getElementById('know').addEventListener('click', () => record(true));
+document.getElementById('dontknow').addEventListener('click', () => record(false));
+
+document.addEventListener('keydown', (e) => {
+    if (e.code === 'Space') {
+        e.preventDefault();
+        if (document.getElementById('answer').style.display === 'none') {
+            reveal();
+        }
+    } else if (e.key === '1') {
+        if (document.getElementById('answer').style.display !== 'none') {
+            record(true);
+        }
+    } else if (e.key === '2') {
+        if (document.getElementById('answer').style.display !== 'none') {
+            record(false);
+        }
+    }
+});
+
+loadWord();


### PR DESCRIPTION
## Summary
- create `flashcard.html` and `flashcard.js` for a simple flashcard UI
- support keyboard shortcuts and logging results
- expose new endpoints in `server.py` for serving the page, choosing the next word and recording interactions

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68416f5c12a0832aaad1a89a778e176e