### PR TITLE
Improve flashcard UI

### DIFF
--- a/flashcard.html
+++ b/flashcard.html
@@ -8,12 +8,13 @@
 <body>
     <div class="container" id="card">
         <h1 id="word"></h1>
+        <hr id="divider">
         <div id="pinyin"></div>
         <div id="meaning" style="display:none;"></div>
-        <button id="reveal">Reveal Translation (Space)</button>
+        <button id="reveal" class="btn">Reveal Translation (Space)</button>
         <div id="answer" style="display:none; margin-top:1em;">
-            <button id="know">I know this word (1)</button>
-            <button id="dontknow">I don't know this word (2)</button>
+            <button id="right" class="btn btn-right">Right</button>
+            <button id="wrong" class="btn btn-wrong">Wrong</button>
         </div>
     </div>
     <script src="flashcard.js"></script>

--- a/flashcard.js
+++ b/flashcard.js
@@ -37,8 +37,8 @@ async function record(known) {
 }
 
 document.getElementById('reveal').addEventListener('click', reveal);
-document.getElementById('know').addEventListener('click', () => record(true));
-document.getElementById('dontknow').addEventListener('click', () => record(false));
+document.getElementById('right').addEventListener('click', () => record(true));
+document.getElementById('wrong').addEventListener('click', () => record(false));
 
 document.addEventListener('keydown', (e) => {
     if (e.code === 'Space') {

--- a/style.css
+++ b/style.css
@@ -87,3 +87,54 @@ th, td {
 th {
     background-color: #f2f2f2;
 }
+# Flashcard specific styling
+#card {
+    text-align: center;
+    border: 1px solid #ddd;
+    padding: 40px;
+    margin-top: 40px;
+}
+
+#word {
+    font-size: 5em;
+    margin: 0.2em 0;
+}
+
+#pinyin {
+    font-size: 1.5em;
+    margin-bottom: 0.5em;
+}
+
+#meaning {
+    margin-top: 0.5em;
+}
+
+#divider {
+    margin: 10px auto;
+    width: 50%;
+    border: none;
+    border-top: 1px solid #ccc;
+}
+
+.btn {
+    padding: 10px 20px;
+    font-size: 1em;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin: 0 5px;
+}
+
+.btn-right {
+    background-color: #4caf50;
+    color: white;
+}
+
+.btn-wrong {
+    background-color: #e16e6e;
+    color: white;
+}
+
+.btn:hover {
+    opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- center align flashcards and tweak container borders
- separate character and pinyin with a divider
- use redesigned buttons for Right and Wrong answers
- enlarge the Chinese character

## Testing
- `python -m py_compile server.py && echo 'py_compile success'`

------
https://chatgpt.com/codex/tasks/task_e_684171bf0ca4832a8c93e4718077726f