### PR TITLE
Refine flashcard design

### DIFF
--- a/flashcard.html
+++ b/flashcard.html
@@ -7,14 +7,19 @@
 </head>
 <body>
     <div class="container" id="card">
-        <h1 id="word"></h1>
+        <div id="front">
+            <h1 id="word"></h1>
+            <div id="pinyin"></div>
+            <button id="reveal" class="btn">Reveal Translation (Space)</button>
+        </div>
         <hr id="divider">
-        <div id="pinyin"></div>
-        <div id="meaning" style="display:none;"></div>
-        <button id="reveal" class="btn">Reveal Translation (Space)</button>
-        <div id="answer" style="display:none; margin-top:1em;">
-            <button id="right" class="btn btn-right">Right</button>
-            <button id="wrong" class="btn btn-wrong">Wrong</button>
+        <div id="back">
+            <div id="meaning" style="display:none;"></div>
+            <hr id="button-divider" style="display:none;">
+            <div id="answer" style="display:none; margin-top:1em;">
+                <button id="right" class="btn btn-right">Right</button>
+                <button id="wrong" class="btn btn-wrong">Wrong</button>
+            </div>
         </div>
     </div>
     <script src="flashcard.js"></script>

--- a/flashcard.js
+++ b/flashcard.js
@@ -18,11 +18,13 @@ async function loadWord() {
     document.getElementById('meaning').textContent = data.meaning;
     document.getElementById('meaning').style.display = 'none';
     document.getElementById('answer').style.display = 'none';
+    document.getElementById('button-divider').style.display = 'none';
 }
 
 function reveal() {
     document.getElementById('meaning').style.display = 'block';
-    document.getElementById('answer').style.display = 'block';
+    document.getElementById('button-divider').style.display = 'block';
+    document.getElementById('answer').style.display = 'flex';
 }
 
 async function record(known) {

--- a/style.css
+++ b/style.css
@@ -87,12 +87,20 @@ th, td {
 th {
     background-color: #f2f2f2;
 }
-# Flashcard specific styling
+/* Flashcard specific styling */
 #card {
     text-align: center;
     border: 1px solid #ddd;
     padding: 40px;
-    margin-top: 40px;
+    margin: 40px auto;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#front, #back {
+    width: 100%;
 }
 
 #word {
@@ -107,22 +115,28 @@ th {
 
 #meaning {
     margin-top: 0.5em;
+    font-size: 1.3em;
 }
 
-#divider {
-    margin: 10px auto;
-    width: 50%;
+#divider, #button-divider {
+    margin: 15px auto;
+    width: 80%;
     border: none;
-    border-top: 1px solid #ccc;
+    border-top: 1px solid #e0e0e0;
 }
 
 .btn {
     padding: 10px 20px;
     font-size: 1em;
     border: none;
-    border-radius: 4px;
+    border-radius: 6px;
     cursor: pointer;
     margin: 0 5px;
+    min-width: 120px;
+    background-color: #4a90e2;
+    color: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    transition: background-color 0.2s, box-shadow 0.2s;
 }
 
 .btn-right {
@@ -136,5 +150,12 @@ th {
 }
 
 .btn:hover {
-    opacity: 0.9;
+    background-color: #357abd;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.15);
+}
+
+#answer {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
 }


### PR DESCRIPTION
## Summary
- restructure flashcard markup for clear front/back sections
- modernize card and button styling
- show/hide new dividers in JS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841737f1100832a95641e76cd48202d