### PR TITLE
Improve text reading field styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,10 +33,16 @@ body {
 }
 
 #text {
-    font-size: 1.5em;
-    line-height: 2;
+    padding: 20px;
+    margin: 10px auto;
+    width: 80%;
+    max-width: 900px;
+    background-color: #ffffff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    font-family: 'KaiTi', 'STKaiti', 'DFKai-SB', 'SimKai', serif;
+    font-size: 42px;
+    line-height: 1.4;
     margin-bottom: 1em;
-    font-family: "Noto Serif TC", "KaiTi", serif;
 }
 
 .word {
@@ -207,15 +213,20 @@ th {
 }
 
 .ruby-char {
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
+    position: relative;
+    margin-right: 0.3em;
+    text-shadow: 1px 1px #ddd;
 }
 
 .rt-bpmf {
-    color: red;
-    font-size: 0.6em;
-    line-height: 1;
-    margin-left: 2px;
     writing-mode: vertical-rl;
-    text-orientation: upright;
+    position: absolute;
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
+    font-size: 0.3em;
+    color: #d9534f;
+    font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- update reading field styles to match previous design
- align Bopomofo ruby text vertically with main characters

## Testing
- `npx eslint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef623d08832a8aa88f885c9c9458