### PR TITLE
Enhance reading field and bopomofo behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,12 +35,12 @@ body {
 #text {
     padding: 20px;
     margin: 10px auto;
-    width: 80%;
+    width: 90%;
     max-width: 900px;
     background-color: #ffffff;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     font-family: 'KaiTi', 'STKaiti', 'DFKai-SB', 'SimKai', serif;
-    font-size: 42px;
+    font-size: 34px;
     line-height: 1.4;
     margin-bottom: 1em;
 }

--- a/text_selection.js
+++ b/text_selection.js
@@ -20,20 +20,23 @@ async function loadTokens() {
             span.classList.add('word');
             span.addEventListener('click', () => {
                 span.classList.toggle('unknown');
+            });
+            span.addEventListener('mouseenter', () => {
                 const bpmf = span.dataset.bpmf;
-                if (!bpmf) return;
+                if (!bpmf || span.dataset.showing === 'true') return;
+                const chars = Array.from(span.dataset.original);
+                const readings = bpmf.split(' ');
+                const html = chars.map((c, i) => {
+                    const r = readings[i] || '';
+                    return `<span class="ruby-char">${c}<span class="rt-bpmf">${r}</span></span>`;
+                }).join('');
+                span.innerHTML = html;
+                span.dataset.showing = 'true';
+            });
+            span.addEventListener('mouseleave', () => {
                 if (span.dataset.showing === 'true') {
                     span.textContent = span.dataset.original;
                     span.dataset.showing = 'false';
-                } else {
-                    const chars = Array.from(span.dataset.original);
-                    const readings = bpmf.split(' ');
-                    const html = chars.map((c, i) => {
-                        const r = readings[i] || '';
-                        return `<span class="ruby-char">${c}<span class="rt-bpmf">${r}</span></span>`;
-                    }).join('');
-                    span.innerHTML = html;
-                    span.dataset.showing = 'true';
                 }
             });
             container.append(span);


### PR DESCRIPTION
## Summary
- increase reading field width and decrease font size
- show bopomofo pronunciation on hover instead of click
- keep click interaction for toggling unknown words

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f220cfe0832a9853d010b83ae137